### PR TITLE
Add new fields to tests

### DIFF
--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -61,6 +61,7 @@ class BaseTestCase(TestCase):
                 "id": name,
                 "password": name,
                 "contact_email": "%s@notmyidea.org" % name,
+                "default_currency": "USD",
             },
         )
 
@@ -70,6 +71,7 @@ class BaseTestCase(TestCase):
             name=str(name),
             password=generate_password_hash(name),
             contact_email="%s@notmyidea.org" % name,
+            default_currency="USD",
         )
         models.db.session.add(project)
         models.db.session.commit()
@@ -256,6 +258,7 @@ class BudgetTestCase(IhatemoneyTestCase):
                     "id": "raclette",
                     "password": "party",
                     "contact_email": "raclette@notmyidea.org",
+                    "default_currency": "USD",
                 },
             )
 
@@ -275,6 +278,7 @@ class BudgetTestCase(IhatemoneyTestCase):
                     "id": "raclette",  # already used !
                     "password": "party",
                     "contact_email": "raclette@notmyidea.org",
+                    "default_currency": "USD",
                 },
             )
 
@@ -292,6 +296,7 @@ class BudgetTestCase(IhatemoneyTestCase):
                     "id": "raclette",
                     "password": "party",
                     "contact_email": "raclette@notmyidea.org",
+                    "default_currency": "USD",
                 },
             )
 
@@ -312,6 +317,7 @@ class BudgetTestCase(IhatemoneyTestCase):
                     "id": "raclette",
                     "password": "party",
                     "contact_email": "raclette@notmyidea.org",
+                    "default_currency": "USD",
                 },
             )
 
@@ -331,6 +337,7 @@ class BudgetTestCase(IhatemoneyTestCase):
                     "id": "raclette",
                     "password": "party",
                     "contact_email": "raclette@notmyidea.org",
+                    "default_currency": "USD",
                 },
             )
 
@@ -842,6 +849,7 @@ class BudgetTestCase(IhatemoneyTestCase):
             "name": "Super raclette party!",
             "contact_email": "alexis@notmyidea.org",
             "password": "didoudida",
+            "default_currency": "USD",
         }
 
         resp = self.client.post("/raclette/edit", data=new_data, follow_redirects=True)
@@ -850,6 +858,7 @@ class BudgetTestCase(IhatemoneyTestCase):
 
         self.assertEqual(project.name, new_data["name"])
         self.assertEqual(project.contact_email, new_data["contact_email"])
+        self.assertEqual(project.default_currency, new_data["default_currency"])
         self.assertTrue(check_password_hash(project.password, new_data["password"]))
 
         # Editing a project with a wrong email address should fail
@@ -1207,6 +1216,7 @@ class APITestCase(IhatemoneyTestCase):
                 "id": id,
                 "password": password,
                 "contact_email": contact,
+                "default_currency": "USD",
             },
         )
 
@@ -1268,6 +1278,7 @@ class APITestCase(IhatemoneyTestCase):
                 "id": "raclette",
                 "password": "raclette",
                 "contact_email": "not-an-email",
+                "default_currency": "USD",
             },
         )
 
@@ -1296,6 +1307,7 @@ class APITestCase(IhatemoneyTestCase):
             "members": [],
             "name": "raclette",
             "contact_email": "raclette@notmyidea.org",
+            "default_currency": "USD",
             "id": "raclette",
         }
         decoded_resp = json.loads(resp.data.decode("utf-8"))
@@ -1306,6 +1318,7 @@ class APITestCase(IhatemoneyTestCase):
             "/api/projects/raclette",
             data={
                 "contact_email": "yeah@notmyidea.org",
+                "default_currency": "USD",
                 "password": "raclette",
                 "name": "The raclette party",
             },
@@ -1322,6 +1335,7 @@ class APITestCase(IhatemoneyTestCase):
         expected = {
             "name": "The raclette party",
             "contact_email": "yeah@notmyidea.org",
+            "default_currency": "USD",
             "members": [],
             "id": "raclette",
         }
@@ -1333,6 +1347,7 @@ class APITestCase(IhatemoneyTestCase):
             "/api/projects/raclette",
             data={
                 "contact_email": "yeah@notmyidea.org",
+                "default_currency": "USD",
                 "password": "tartiflette",
                 "name": "The raclette party",
             },
@@ -1900,6 +1915,7 @@ class APITestCase(IhatemoneyTestCase):
             "contact_email": "raclette@notmyidea.org",
             "id": "raclette",
             "name": "raclette",
+            "default_currency": "USD",
         }
 
         self.assertStatus(200, req)

--- a/ihatemoney/tests/tests.py
+++ b/ihatemoney/tests/tests.py
@@ -1530,6 +1530,8 @@ class APITestCase(IhatemoneyTestCase):
                 "payed_for": ["1", "2"],
                 "amount": "25",
                 "external_link": "https://raclette.fr",
+                "original_currency": "USD",
+                "original_amount": "25",
             },
             headers=self.get_auth("raclette"),
         )
@@ -1555,6 +1557,8 @@ class APITestCase(IhatemoneyTestCase):
             "amount": 25.0,
             "date": "2011-08-10",
             "id": 1,
+            "original_amount": 25.0,
+            "original_currency": "USD",
             "external_link": "https://raclette.fr",
         }
 
@@ -1583,6 +1587,8 @@ class APITestCase(IhatemoneyTestCase):
                 "payed_for": ["1", "2"],
                 "amount": "25",
                 "external_link": "https://raclette.fr",
+                "original_amount": "25",
+                "original_currency": "USD",
             },
             headers=self.get_auth("raclette"),
         )
@@ -1602,6 +1608,8 @@ class APITestCase(IhatemoneyTestCase):
                 "payed_for": ["1", "2"],
                 "amount": "25",
                 "external_link": "https://raclette.fr",
+                "original_amount": "25",
+                "original_currency": "USD",
             },
             headers=self.get_auth("raclette"),
         )
@@ -1624,6 +1632,8 @@ class APITestCase(IhatemoneyTestCase):
             "amount": 25.0,
             "date": "2011-09-10",
             "external_link": "https://raclette.fr",
+            "original_amount": 25.0,
+            "original_currency": "USD",
             "id": 1,
         }
 
@@ -1674,6 +1684,8 @@ class APITestCase(IhatemoneyTestCase):
                     "payer": "1",
                     "payed_for": ["1", "2"],
                     "amount": input_amount,
+                    "original_currency": "USD",
+                    "original_amount": input_amount,
                 },
                 headers=self.get_auth("raclette"),
             )
@@ -1701,6 +1713,8 @@ class APITestCase(IhatemoneyTestCase):
                 "date": "2011-08-10",
                 "id": id,
                 "external_link": "",
+                "original_currency": "USD",
+                "original_amount": input_amount,
             }
 
             got = json.loads(req.data.decode("utf-8"))
@@ -1843,6 +1857,8 @@ class APITestCase(IhatemoneyTestCase):
             "date": "2011-08-10",
             "id": 1,
             "external_link": "",
+            "original_amount": 25.0,
+            "original_currency": "USD",
         }
         got = json.loads(req.data.decode("utf-8"))
         self.assertEqual(


### PR DESCRIPTION
- Added `default_currency` to Project model tests
- Added `original_currency` and `original_amount` to Bill model tests

NOTE: This PR would fail for now, because the new fields are not being parsed in POST requests.
It has to be done in forms.py, and this PR is waiting for 'form submission' task to be pushed.
I'm going to re-run the tests once we have 'form submission' task merged.